### PR TITLE
Add mobile list view matching Dashboard style

### DIFF
--- a/client/src/components/AlbumRowMobile.jsx
+++ b/client/src/components/AlbumRowMobile.jsx
@@ -1,0 +1,46 @@
+import { Music2 } from 'lucide-preact';
+
+export function AlbumRowMobile({ album, onClick, onEdit, onDelete, onLend, onRate, onAcquire, selectionMode, selected, onSelect }) {
+  const handleClick = (e) => {
+    if (selectionMode) {
+      onSelect(album.id);
+    } else if (onClick) {
+      onClick(album);
+    }
+  };
+
+  return (
+    <div
+      class="list-group-item list-group-item-action d-flex align-items-center gap-3 py-2"
+      style={{ cursor: selectionMode || onClick ? 'pointer' : 'default' }}
+      onClick={handleClick}
+    >
+      {selectionMode && (
+        <div style={{ flexShrink: 0 }} onClick={(e) => { e.stopPropagation(); onSelect(album.id); }}>
+          {selected ? (
+            <span class="text-primary">✓</span>
+          ) : (
+            <span class="text-muted">○</span>
+          )}
+        </div>
+      )}
+
+      {album.cover_url ? (
+        <img src={album.cover_url} alt="" style={{ width: 40, height: 40, objectFit: 'cover', borderRadius: 4, flexShrink: 0 }} />
+      ) : (
+        <div class="d-flex align-items-center justify-content-center bg-secondary-lt rounded" style={{ width: 40, height: 40, flexShrink: 0 }}>
+          <Music2 size={18} class="text-muted" />
+        </div>
+      )}
+
+      <div class="flex-grow-1 overflow-hidden">
+        <div class="fw-semibold text-truncate small">{album.title}</div>
+        <div class="text-muted" style={{ fontSize: '0.75rem' }}>{album.artist?.name || album.artist}</div>
+      </div>
+
+      {album.year && (
+        <span class="text-muted flex-shrink-0" style={{ fontSize: '0.75rem' }}>{album.year}</span>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -3,6 +3,7 @@ import { albumsApi } from '../api/albums.js';
 import { api } from '../api/client.js';
 import { AlbumCard } from '../components/AlbumCard.jsx';
 import { AlbumRow } from '../components/AlbumRow.jsx';
+import { AlbumRowMobile } from '../components/AlbumRowMobile.jsx';
 import { Pagination } from '../components/Pagination.jsx';
 import { useI18n } from '../config/i18n/index.jsx';
 import { Search, Grid, List, X, Plus, Disc, Database, AlertCircle, Music, CheckSquare, Square, Trash2, Settings } from 'lucide-preact';
@@ -395,46 +396,69 @@ export function Collections({ navigate, params = {} }) {
                     )}
 
                     {effectiveViewMode === 'list' && (
-                      <div class="card">
-                        <div class="table-responsive">
-                          <table class="table table-vcenter card-table">
-                            <thead>
-                              <tr>
-                                {selectionMode && <th style={{ width: 40 }}></th>}
-                                <th class="d-none d-sm-table-cell">{t('table.cover')}</th>
-                                <th>{t('table.title')}</th>
-                                <th>{t('table.artist')}</th>
-                                <th class="d-none d-lg-table-cell">{t('table.year')}</th>
-                                <th class="d-none d-lg-table-cell">{t('table.genre')}</th>
-                                <th class="d-none d-md-table-cell">{t('table.rating')}</th>
-                                <th class="d-none d-md-table-cell">{t('table.label')}</th>
-                              </tr>
-                            </thead>
-                            <tbody>
+                      <>
+                        {/* Mobile list view - Dashboard style */}
+                        {isMobile && (
+                          <div class="card">
+                            <div class="list-group list-group-flush">
                               {albums.map(album => (
-                                <>
-                                  {selectionMode && (
-                                    <td style={{ cursor: 'pointer' }} onClick={() => toggleSelect(album.id)}>
-                                      {selectedIds.has(album.id)
-                                        ? <CheckSquare size={18} class="text-primary" />
-                                        : <Square size={18} class="text-muted" />}
-                                    </td>
-                                  )}
-                                  <AlbumRow
-                                    key={album.id}
-                                    album={album}
-                                    onClick={selectionMode ? () => toggleSelect(album.id) : (a) => navigate('detail', { id: a.id })}
-                                    onEdit={selectionMode ? undefined : (a) => navigate('edit', { id: a.id })}
-                                    onDelete={selectionMode ? undefined : (a) => setDeleteTarget(a)}
-                                    onLend={selectionMode ? undefined : (a) => { setLendTarget(a); setLentTo(a.lent_to || ''); }}
-                                    onRate={selectionMode ? undefined : handleRate}
-                                  />
-                                </>
+                                <AlbumRowMobile
+                                  key={album.id}
+                                  album={album}
+                                  onClick={selectionMode ? undefined : (a) => navigate('detail', { id: a.id })}
+                                  selectionMode={selectionMode}
+                                  selected={selectedIds.has(album.id)}
+                                  onSelect={toggleSelect}
+                                />
                               ))}
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* Desktop table view */}
+                        {!isMobile && (
+                          <div class="card">
+                            <div class="table-responsive">
+                              <table class="table table-vcenter card-table">
+                                <thead>
+                                  <tr>
+                                    {selectionMode && <th style={{ width: 40 }}></th>}
+                                    <th class="d-none d-sm-table-cell">{t('table.cover')}</th>
+                                    <th>{t('table.title')}</th>
+                                    <th>{t('table.artist')}</th>
+                                    <th class="d-none d-lg-table-cell">{t('table.year')}</th>
+                                    <th class="d-none d-lg-table-cell">{t('table.genre')}</th>
+                                    <th class="d-none d-md-table-cell">{t('table.rating')}</th>
+                                    <th class="d-none d-md-table-cell">{t('table.label')}</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {albums.map(album => (
+                                    <>
+                                      {selectionMode && (
+                                        <td style={{ cursor: 'pointer' }} onClick={() => toggleSelect(album.id)}>
+                                          {selectedIds.has(album.id)
+                                            ? <CheckSquare size={18} class="text-primary" />
+                                            : <Square size={18} class="text-muted" />}
+                                        </td>
+                                      )}
+                                      <AlbumRow
+                                        key={album.id}
+                                        album={album}
+                                        onClick={selectionMode ? () => toggleSelect(album.id) : (a) => navigate('detail', { id: a.id })}
+                                        onEdit={selectionMode ? undefined : (a) => navigate('edit', { id: a.id })}
+                                        onDelete={selectionMode ? undefined : (a) => setDeleteTarget(a)}
+                                        onLend={selectionMode ? undefined : (a) => { setLentTarget(a); setLentTo(a.lent_to || ''); }}
+                                        onRate={selectionMode ? undefined : handleRate}
+                                      />
+                                    </>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        )}
+                      </>
                     )}
 
                     {/* Bottom controls */}

--- a/client/src/pages/WantList.jsx
+++ b/client/src/pages/WantList.jsx
@@ -3,6 +3,7 @@ import { albumsApi } from '../api/albums.js';
 import { api } from '../api/client.js';
 import { AlbumCard } from '../components/AlbumCard.jsx';
 import { AlbumRow } from '../components/AlbumRow.jsx';
+import { AlbumRowMobile } from '../components/AlbumRowMobile.jsx';
 import { Pagination } from '../components/Pagination.jsx';
 import { useI18n } from '../config/i18n/index.jsx';
 import { Search, Grid, List, X, Plus, Heart, Database, Music, CheckCheck, Settings } from 'lucide-preact';
@@ -17,7 +18,7 @@ export function WantList({ navigate, params = {} }) {
   const [activeDatabase, setActiveDatabase] = useState(null);
   const [dbCheckComplete, setDbCheckComplete] = useState(false);
   const [viewMode, setViewMode] = useState(() => localStorage.getItem('jewelbox-wantlist-viewMode') || 'grid');
-  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 576);
+const [isMobile, setIsMobile] = useState(() => window.innerWidth < 576);
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(() => {
     const saved = localStorage.getItem('jewelbox-wantlist-limit');
@@ -283,36 +284,56 @@ export function WantList({ navigate, params = {} }) {
                         )}
 
                         {effectiveViewMode === 'list' && (
-                          <div class="card">
-                            <div class="table-responsive">
-                              <table class="table table-vcenter card-table">
-                                <thead>
-                                  <tr>
-                                    <th class="d-none d-sm-table-cell">{t('table.cover')}</th>
-                                    <th>{t('table.title')}</th>
-                                    <th>{t('table.artist')}</th>
-                                    <th class="d-none d-lg-table-cell">{t('table.year')}</th>
-                                    <th class="d-none d-lg-table-cell">{t('table.genre')}</th>
-                                    <th class="d-none d-md-table-cell">{t('table.rating')}</th>
-                                    <th class="d-none d-md-table-cell">{t('table.label')}</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
+                          <>
+                            {/* Mobile list view - Dashboard style */}
+                            {isMobile && (
+                              <div class="card">
+                                <div class="list-group list-group-flush">
                                   {albums.map(album => (
-                                    <AlbumRow
+                                    <AlbumRowMobile
                                       key={album.id}
                                       album={album}
                                       onClick={(a) => navigate('detail', { id: a.id })}
-                                      onEdit={(a) => navigate('edit', { id: a.id })}
-                                      onDelete={(a) => setDeleteTarget(a)}
-                                      onAcquire={(a) => setAcquireTarget(a)}
-                                      onRate={handleRate}
                                     />
                                   ))}
-                                </tbody>
-                              </table>
-                            </div>
-                          </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* Desktop table view */}
+                            {!isMobile && (
+                              <div class="card">
+                                <div class="table-responsive">
+                                  <table class="table table-vcenter card-table">
+                                    <thead>
+                                      <tr>
+                                        <th class="d-none d-sm-table-cell">{t('table.cover')}</th>
+                                        <th>{t('table.title')}</th>
+                                        <th>{t('table.artist')}</th>
+                                        <th class="d-none d-lg-table-cell">{t('table.year')}</th>
+                                        <th class="d-none d-lg-table-cell">{t('table.genre')}</th>
+                                        <th class="d-none d-md-table-cell">{t('table.rating')}</th>
+                                        <th class="d-none d-md-table-cell">{t('table.label')}</th>
+                                      </tr>
+                                    </thead>
+                                    <tbody>
+                                      {albums.map(album => (
+                                        <AlbumRow
+                                          key={album.id}
+                                          album={album}
+                                          onClick={(a) => navigate('detail', { id: a.id })}
+                                          onEdit={(a) => navigate('edit', { id: a.id })}
+                                          onDelete={(a) => setDeleteTarget(a)}
+                                          onAcquire={(a) => setAcquireTarget(a)}
+                                          onRate={handleRate}
+                                        />
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                              </div>
+                            )}
+                          </>
                         )}
 
                         <div class="mt-4 d-flex justify-content-between align-items-center">


### PR DESCRIPTION
- Create AlbumRowMobile component with Dashboard-style layout
- Use mobile list view on Collections and WantList pages
- Keep desktop table view unchanged
- Display cover (40x40), title, artist, and year on mobile

