### PR TITLE
Improve UX: focus, scroll-to-top, navigation enhancements, and save-a…

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'preact/hooks';
 import { useI18n } from '../config/i18n/index.jsx';
 import { Header } from './Header.jsx';
 import { TopMenu } from './TopMenu.jsx';
+import { ArrowUp } from 'lucide-preact';
 
 export function Layout({ children, navigate, currentPage }) {
   const { t } = useI18n();
@@ -12,6 +13,7 @@ export function Layout({ children, navigate, currentPage }) {
     }
     return saved === 'dark';
   });
+  const [showScrollTop, setShowScrollTop] = useState(false);
 
   useEffect(() => {
     const theme = isDark ? 'dark' : 'light';
@@ -19,8 +21,20 @@ export function Layout({ children, navigate, currentPage }) {
     localStorage.setItem('jewelbox-theme', theme);
   }, [isDark]);
 
+  useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   const toggleTheme = () => {
     setIsDark(!isDark);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
@@ -30,6 +44,16 @@ export function Layout({ children, navigate, currentPage }) {
       <main class="main-content">
         {children}
       </main>
+      {showScrollTop && (
+        <button
+          class="btn btn-primary position-fixed bottom-0 end-0 m-4 rounded-circle shadow"
+          style={{ width: 48, height: 48, zIndex: 1000 }}
+          onClick={scrollToTop}
+          title={t('common.scrollToTop')}
+        >
+          <ArrowUp size={20} />
+        </button>
+      )}
     </div>
   );
 }

--- a/client/src/config/i18n/fr.json
+++ b/client/src/config/i18n/fr.json
@@ -36,7 +36,11 @@
     "albums": "Albums",
     "lent": "Prêtés",
     "genres": "Genres",
-    "rated": "Notés"
+    "rated": "Notés",
+    "scrollToTop": "Remonter en haut",
+    "addSuccess": "Album ajouté avec succès",
+    "addWishSuccess": "Souhait ajouté avec succès",
+    "updateSuccess": "Album modifié avec succès"
   },
   "home": {
     "searchPlaceholder": "Rechercher un album, un artiste...",
@@ -165,6 +169,7 @@
     },
     "actions": {
       "save": "Enregistrer",
+      "saveAndAdd": "Enregistrer et ajouter",
       "cancel": "Annuler",
       "delete": "Supprimer",
       "confirmDelete": "Êtes-vous sûr de vouloir supprimer cet album ?",

--- a/client/src/pages/AlbumForm.jsx
+++ b/client/src/pages/AlbumForm.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'preact/hooks';
 import { api } from '../api/client.js';
 import { StarRating } from '../components/StarRating.jsx';
-import { Plus, ArrowLeft, Pencil, AlertCircle, Search, ChevronRight, Upload, Info, ListOrdered, X, Music2, Save, ImageIcon, CopyX } from 'lucide-preact';
+import { Plus, ArrowLeft, Pencil, AlertCircle, Search, ChevronRight, Upload, Info, ListOrdered, X, Music2, Save, ImageIcon, CopyX, FastForward } from 'lucide-preact';
 import { useI18n } from '../config/i18n/index.jsx';
 
 function Combobox({ value, onChange, options = [], placeholder, required, id }) {
@@ -75,6 +75,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
   const { t } = useI18n();
   const isEdit = Boolean(albumId);
   const fromWantList = Boolean(params.fromWantList);
+  const returnPage = params.returnPage || 1;
   const [form, setForm] = useState({ ...EMPTY_FORM, is_wanted: fromWantList });
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -93,6 +94,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
   const [toast, setToast] = useState(null);
   const [duplicateWarning, setDuplicateWarning] = useState(null);
   const coverInputRef = useRef();
+  const searchInputRef = useRef();
 
   // Load known artists, labels, genres for datalists
   useEffect(() => {
@@ -106,6 +108,13 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
       setKnownGenres(genres);
     });
   }, []);
+
+  // Auto-focus search input when adding a new album
+  useEffect(() => {
+    if (!isEdit && searchInputRef.current && !params.initialSearch) {
+      searchInputRef.current.focus();
+    }
+  }, [isEdit, params.initialSearch]);
 
   // Auto-trigger search if launched from quick add
   useEffect(() => {
@@ -169,7 +178,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
     } catch { setDuplicateWarning(null); }
   };
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e, saveAndAddAnother = false) => {
     e.preventDefault();
     setSaving(true);
     setError(null);
@@ -182,10 +191,30 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
       };
       if (isEdit) {
         await api.updateAlbum(albumId, payload);
+        showToast(t('albumForm.updateSuccess'), 'success');
       } else {
         await api.createAlbum(payload);
+        if (fromWantList) {
+          showToast(t('albumForm.addWishSuccess'), 'success');
+          if (saveAndAddAnother) {
+            setForm({ ...EMPTY_FORM, is_wanted: true });
+            setSearchQuery('');
+            searchInputRef.current?.focus();
+          } else {
+            setForm({ ...EMPTY_FORM, is_wanted: true });
+            setSearchQuery('');
+          }
+        } else {
+          if (saveAndAddAnother) {
+            showToast(t('albumForm.addSuccess'), 'success');
+            setForm({ ...EMPTY_FORM, is_wanted: false });
+            setSearchQuery('');
+            searchInputRef.current?.focus();
+          } else {
+            navigate('collections', { page: returnPage, successMessage: t('albumForm.addSuccess') });
+          }
+        }
       }
-      navigate(fromWantList ? 'wantlist' : 'collections');
     } catch (e) {
       showToast(e.message, 'danger');
     } finally {
@@ -314,7 +343,13 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
       <div class="page-header d-print-none mb-3">
         <div class="row align-items-center">
           <div class="col-auto">
-            <button class="btn btn-outline-secondary" onClick={() => navigate(fromWantList ? 'wantlist' : 'collections')}>
+            <button class="btn btn-outline-secondary" onClick={() => {
+              if (fromWantList) {
+                navigate('wantlist', { page: returnPage });
+              } else {
+                navigate('collections', { page: returnPage });
+              }
+            }}>
               <ArrowLeft size={16} class="me-1" />{t('common.back')}
             </button>
           </div>
@@ -376,6 +411,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
               <label class="form-label small">{t('albumForm.externalSearchPlaceholder')}</label>
               <div class="input-group">
                 <input
+                  ref={searchInputRef}
                   type="text"
                   class="form-control"
                   placeholder={t('albumForm.externalSearchPlaceholder')}
@@ -711,16 +747,31 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
           </div>
 
           {/* Form actions */}
-          <div class="col-12 d-flex gap-2 justify-content-end mb-4">
-            <button type="button" class="btn" onClick={() => navigate(fromWantList ? 'wantlist' : 'collections')}>
-              {t('albumForm.actions.cancel')}
-            </button>
-            <button type="submit" class="btn btn-primary btn-fixed-height" disabled={saving}>
+          <div class="col-12 d-flex flex-column flex-sm-row gap-2 justify-content-end mb-4">
+            <button type="submit" class="btn btn-primary" disabled={saving}>
               {saving ? (
                 <><span class="spinner-border spinner-border-xs me-1"></span><span>{t('common.loading')}</span></>
               ) : (
                 <>{isEdit ? <Save size={16} class="me-1" /> : <Plus size={16} class="me-1" />}<span>{t('albumForm.actions.save')}</span></>
               )}
+            </button>
+            {!isEdit && (
+              <button type="button" class="btn btn-outline-secondary" disabled={saving} onClick={(e) => handleSubmit(e, true)}>
+                {saving ? (
+                  <><span class="spinner-border spinner-border-xs me-1"></span><span>{t('common.loading')}</span></>
+                ) : (
+                  <span>{t('albumForm.actions.saveAndAdd')}</span>
+                )}
+              </button>
+            )}
+            <button type="button" class="btn btn-outline-secondary" onClick={() => {
+              if (fromWantList) {
+                navigate('wantlist', { page: returnPage });
+              } else {
+                navigate('collections', { page: returnPage });
+              }
+            }}>
+              {t('albumForm.actions.cancel')}
             </button>
           </div>
         </div>

--- a/client/src/pages/Collections.jsx
+++ b/client/src/pages/Collections.jsx
@@ -285,7 +285,7 @@ export function Collections({ navigate, params = {} }) {
                       <button class="btn btn-outline-secondary btn-sm" onClick={() => setSelectionMode(true)}>
                         <CheckSquare size={16} class="me-1" />{t('common.select')}
                       </button>
-                      <button class="btn btn-primary btn-sm" onClick={() => navigate('add')}>
+                      <button class="btn btn-primary btn-sm" onClick={() => navigate('add', { returnPage: page })}>
                         <Plus size={16} class="me-1" />{t('common.addAlbum')}
                       </button>
                     </>
@@ -471,7 +471,7 @@ export function Collections({ navigate, params = {} }) {
                     </p>
                     <div class="mt-3">
                       {total === 0 && !filters.search ? (
-                        <button class="btn btn-primary" onClick={() => navigate('add')}>
+                        <button class="btn btn-primary" onClick={() => navigate('add', { returnPage: page })}>
                           <Plus size={16} class="me-1" />
                           {t('common.addAlbum')}
                         </button>

--- a/client/src/pages/WantList.jsx
+++ b/client/src/pages/WantList.jsx
@@ -189,7 +189,7 @@ export function WantList({ navigate, params = {} }) {
                   <Heart size={24} class="me-2 text-danger" />
                   {t('menu.wantlist')}
                 </h2>
-                <button class="btn btn-danger btn-sm" onClick={() => navigate('add', { fromWantList: true })}>
+                <button class="btn btn-danger btn-sm" onClick={() => navigate('add', { fromWantList: true, returnPage: page })}>
                   <Plus size={16} class="me-1" />
                   {t('wantlist.addToWishlist')}
                 </button>
@@ -335,7 +335,7 @@ export function WantList({ navigate, params = {} }) {
                         </p>
                         {!filters.search && (
                           <div class="mt-3">
-                            <button class="btn btn-danger" onClick={() => navigate('add', { fromWantList: true })}>
+                            <button class="btn btn-danger" onClick={() => navigate('add', { fromWantList: true, returnPage: page })}>
                               <Plus size={16} class="me-1" />
                               {t('wantlist.addToWishlist')}
                             </button>


### PR DESCRIPTION
- Auto-focus search input when adding a CD
- Add scroll-to-top button (appears after 300px scroll)
- Keep Artist A->Z as default sort (no year option)
- Stay on WantList page after adding a wish with success message
- Return to previous page number after adding album/wish
- Add 'Save and add' button for quick album addition
- Add French translations for success messages and buttons
