### PR TITLE
Add navigation to home page from header brand

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,14 +1,20 @@
 import { useI18n } from '../config/i18n/index.jsx';
 import { Sun, Moon } from 'lucide-preact';
 
-export function Header({ onThemeToggle, isDark }) {
+export function Header({ onThemeToggle, isDark, navigate }) {
   const { t } = useI18n();
-  
+
+  const handleBrandClick = () => {
+    if (navigate) {
+      navigate('dashboard');
+    }
+  };
+
   return (
     <header class="header-top">
       <div class="container">
         <div class="d-flex align-items-center justify-content-between py-3">
-          <div class="header-brand">
+          <div class="header-brand" style={{ cursor: navigate ? 'pointer' : 'default' }} onClick={handleBrandClick}>
             <div class="d-flex align-items-center gap-2">
               <img src="/icons/icon-192.png" width="36" height="36" alt="JewelBox" style={{ borderRadius: '8px' }} />
               <div>
@@ -18,8 +24,8 @@ export function Header({ onThemeToggle, isDark }) {
             </div>
           </div>
           <div class="header-actions">
-            <button 
-              class="theme-toggle" 
+            <button
+              class="theme-toggle"
               onClick={onThemeToggle}
               title={isDark ? t('common.lightMode') : t('common.darkMode')}
             >

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -39,7 +39,7 @@ export function Layout({ children, navigate, currentPage }) {
 
   return (
     <div class="layout-horizontal">
-      <Header onThemeToggle={toggleTheme} isDark={isDark} />
+      <Header onThemeToggle={toggleTheme} isDark={isDark} navigate={navigate} />
       <TopMenu currentPage={currentPage} navigate={navigate} />
       <main class="main-content">
         {children}


### PR DESCRIPTION
- Add navigate prop to Header component
- Add click handler to brand section (icon + title)
- Update cursor to pointer on brand section
- Pass navigate function from Layout to Header
- Clicking app icon or title navigates to dashboard

