### PR TITLE
Fix missing toast message translations

### DIFF
--- a/client/src/config/i18n/fr.json
+++ b/client/src/config/i18n/fr.json
@@ -133,6 +133,10 @@
     "duplicateWarning": "Cet album existe peut-être déjà dans votre collection.",
     "viewExisting": "Voir l'album existant →",
     "clear": "Effacer",
+    "updateSuccess": "Album modifié avec succès",
+    "addSuccess": "Album ajouté avec succès",
+    "addWishSuccess": "Souhait ajouté avec succès",
+    "loadError": "Erreur lors du chargement de l'album",
     "infoTitle": "Informations",
     "tracksTitle": "Pistes",
     "form": {


### PR DESCRIPTION
- Add albumForm.updateSuccess translation
- Add albumForm.addSuccess translation
- Add albumForm.addWishSuccess translation
- Add albumForm.loadError translation
- Fix toast messages showing label names instead of translated text


