### PR TITLE
Add year as secondary sort criterion for albums

### DIFF
--- a/server/src/db/queries.js
+++ b/server/src/db/queries.js
@@ -92,7 +92,7 @@ export function getAlbums({ page = 1, limit = 24, genre, rating, sort = 'title',
   const sortCol = validSorts[sort] || 'a.title';
   const sortDir = order === 'desc' ? 'DESC' : 'ASC';
 
-  const rows = db.prepare(`${ALBUM_SELECT} ${where} ORDER BY ${sortCol} COLLATE NOCASE ${sortDir} LIMIT ? OFFSET ?`)
+  const rows = db.prepare(`${ALBUM_SELECT} ${where} ORDER BY ${sortCol} COLLATE NOCASE ${sortDir}, a.year ASC LIMIT ? OFFSET ?`)
     .all(...params, limit, offset);
 
   const { total } = db.prepare(`


### PR DESCRIPTION
- Change secondary sort from created_at to year
- Primary sort is user's choice (title or artist)
- Secondary sort is album year (oldest first)
- Ensures chronological ordering by album year


