### PR TITLE
Block saving albums already present in collection or wantlist

### DIFF
--- a/client/src/config/i18n/fr.json
+++ b/client/src/config/i18n/fr.json
@@ -140,6 +140,8 @@
     "search": "Rechercher",
     "searchNoResults": "Aucun résultat trouvé pour cette recherche.",
     "duplicateWarning": "Cet album existe peut-être déjà dans votre collection.",
+    "duplicateWarningWishlist": "Cet album est déjà présent dans votre liste de souhaits.",
+    "duplicateWarningCollection": "Cet album est déjà présent dans votre collection.",
     "viewExisting": "Voir l'album existant →",
     "clear": "Effacer",
     "updateSuccess": "Album modifié avec succès",

--- a/client/src/pages/AlbumForm.jsx
+++ b/client/src/pages/AlbumForm.jsx
@@ -296,6 +296,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
       tracks: r.tracks || [],
     });
     setSearchResults([]);
+    checkDuplicate(r.title || '', r.artist_name || '');
   };
 
   const selectRelease = async (r) => {
@@ -402,13 +403,12 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
         <div class="alert alert-warning mb-3 d-flex align-items-center gap-2">
           <CopyX size={18} class="flex-shrink-0" />
           <span>
-            <strong>{t('albumForm.duplicateWarning')}</strong>{' '}
+            <strong>{t(duplicateWarning.is_wanted ? 'albumForm.duplicateWarningWishlist' : 'albumForm.duplicateWarningCollection')}</strong>{' '}
             <button class="btn btn-sm btn-link p-0 ms-1 fw-semibold"
               onClick={() => navigate('detail', { id: duplicateWarning.id })}>
               {t('albumForm.viewExisting')}
             </button>
           </span>
-          <button class="btn-close ms-auto" onClick={() => setDuplicateWarning(null)} />
         </div>
       )}
 
@@ -849,7 +849,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
 
           {/* Form actions */}
           <div class="col-12 d-flex flex-column flex-sm-row gap-2 justify-content-end mb-4">
-            <button type="submit" class="btn btn-primary" disabled={saving}>
+            <button type="submit" class="btn btn-primary" disabled={saving || !!duplicateWarning}>
               {saving ? (
                 <><span class="spinner-border spinner-border-xs me-1"></span><span>{t('common.loading')}</span></>
               ) : (
@@ -857,7 +857,7 @@ export function AlbumForm({ navigate, albumId, params = {} }) {
               )}
             </button>
             {!isEdit && (
-              <button type="button" class="btn btn-outline-secondary" disabled={saving} onClick={(e) => handleSubmit(e, true)}>
+              <button type="button" class="btn btn-outline-secondary" disabled={saving || !!duplicateWarning} onClick={(e) => handleSubmit(e, true)}>
                 {saving ? (
                   <><span class="spinner-border spinner-border-xs me-1"></span><span>{t('common.loading')}</span></>
                 ) : (

--- a/server/src/routes/albums.js
+++ b/server/src/routes/albums.js
@@ -314,7 +314,7 @@ export async function albumRoutes(fastify) {
       if (!title || !artist) return { duplicate: false };
       const db = getDb();
       const row = db.prepare(`
-        SELECT a.id, a.title FROM albums a
+        SELECT a.id, a.title, a.is_wanted FROM albums a
         JOIN artists ar ON ar.id = a.artist_id
         WHERE a.title = ? COLLATE NOCASE AND ar.name = ? COLLATE NOCASE
         LIMIT 1


### PR DESCRIPTION
## 📋 Description

The duplicate check on title/artist now returns whether the existing album is in the collection or wantlist, shows the matching warning, and disables Save/Save and Add until the conflict is resolved. The check is also triggered when applying an external search result, not just on manual field edits.


## 🏷️ Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔨 Refactoring
- [ ] 🐳 Docker / CI
- [ ] 🎨 Style / UI

